### PR TITLE
Erro ao mostrar detalhes da vaga, data estava nula

### DIFF
--- a/app/helpers/jobs_helper.rb
+++ b/app/helpers/jobs_helper.rb
@@ -20,4 +20,12 @@ module JobsHelper
   def checkbox_checked(checked)
     checked.nil? ? false : true
   end
+
+  def has_expire_at?(job)
+    if job.expire_at.nil?
+      'Não informado' 
+    else 
+      job.expire_at.strftime "%d/%m/%Y"
+    end
+  end
 end

--- a/app/views/jobs/show.html.erb
+++ b/app/views/jobs/show.html.erb
@@ -32,12 +32,7 @@
     <dd><%= @job.created_at.strftime "%d/%m/%Y" %></dd>
 
     <dt><%= t(:days_to_expire) %></dt>
-      <%if @job.expire_at.nil? %>
-        Não informado
-      <% else %>
-        <dd><%= @job.expire_at.strftime "%d/%m/%Y" %>
-      <% end %>
-    </dd>
+    <dd><%= has_expire_at?(@job) %></dd>
 
     <dt><%= t(:vacancy_completed) %></dt>
       <% if @job.vacancy_completed == true %>

--- a/app/views/jobs/show.html.erb
+++ b/app/views/jobs/show.html.erb
@@ -19,24 +19,23 @@
   <dl>
     <dt><%= t(:company) %></dt>
     <dd><%= @job.company_name %></dd>
-    
+
     <dt><%= t(:location) %></dt>
     <dd><%= @job.location %></dd>
-    
+
     <% if @job.site_url.present? %>
       <dt><%= t(:site) %></dt>
       <dd><%= link_to @job.site_url, @job.site_url %></dd>
     <% end %>
-    
+
     <dt><%= t(:posted_on) %></dt>
     <dd><%= @job.created_at.strftime "%d/%m/%Y" %></dd>
-    
+
     <dt><%= t(:days_to_expire) %></dt>
-    <dd><%= @job.expire_at.strftime "%d/%m/%Y" %> 
       <%if @job.expire_at.nil? %>
         Não informado
       <% else %>
-        
+        <dd><%= @job.expire_at.strftime "%d/%m/%Y" %>
       <% end %>
     </dd>
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -32,6 +32,7 @@ ActiveRecord::Schema.define(version: 20190811034224) do
     t.text "contact_message", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "days_to_expire"
     t.boolean "vacancy_completed"
     t.datetime "expire_at"
     t.index ["user_id"], name: "index_jobs_on_user_id"


### PR DESCRIPTION
A comparação para verificar se a data estava válida não estava sendo feito de forma correta no show de jobs.